### PR TITLE
Fix Lint error (NewApi).

### DIFF
--- a/library/src/com/welcu/android/zxingfragmentlib/camera/CameraConfigurationManager.java
+++ b/library/src/com/welcu/android/zxingfragmentlib/camera/CameraConfigurationManager.java
@@ -139,7 +139,7 @@ final class CameraConfigurationManager {
 
   private void setOrientation(Camera camera, Camera.Parameters parameters) {
       if (view.getWidth() < view.getHeight()){
-          if (Build.VERSION.SDK_INT==7) {
+          if (Build.VERSION.SDK_INT<=7) {
               parameters.set("orientation", "portrait");
               parameters.setRotation(90);
           } else {


### PR DESCRIPTION
Exchange condition "SDK_INT==7" with "SDK_INT<=7" to avoid Lint from thinking that the condition includes versions older than 7 (which are, in fact, excluded by build.gradle.
