### PR TITLE
Fix problems with Gradle version 0.11

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.android.support:support-v4:19.0.0'
+  compile 'com.android.support:support-v4:19.1.0'
 
 	compile files('libs/zxing-core-2.3.jar')
 	
@@ -13,7 +13,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {

--- a/library/src/com/welcu/android/zxingfragmentlib/camera/CameraConfigurationManager.java
+++ b/library/src/com/welcu/android/zxingfragmentlib/camera/CameraConfigurationManager.java
@@ -16,6 +16,7 @@
 
 package com.welcu.android.zxingfragmentlib.camera;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Point;
@@ -140,12 +141,21 @@ final class CameraConfigurationManager {
   private void setOrientation(Camera camera, Camera.Parameters parameters) {
       if (view.getWidth() < view.getHeight()){
           if (Build.VERSION.SDK_INT<=7) {
-              parameters.set("orientation", "portrait");
-              parameters.setRotation(90);
+              setOrientationBefore8(parameters);
           } else {
-              camera.setDisplayOrientation(90);
+              setOrientation8(camera);
           }
       }
+  }
+
+  private void setOrientationBefore8(Camera.Parameters parameters) {
+      parameters.set("orientation", "portrait");
+      parameters.setRotation(90);
+  }
+
+  @TargetApi(Build.VERSION_CODES.FROYO)
+  private void setOrientation8(Camera camera) {
+      camera.setDisplayOrientation(90);
   }
 
   Point getCameraResolution() {

--- a/library/src/com/welcu/android/zxingfragmentlib/camera/CameraConfigurationManager.java
+++ b/library/src/com/welcu/android/zxingfragmentlib/camera/CameraConfigurationManager.java
@@ -139,7 +139,7 @@ final class CameraConfigurationManager {
 
   private void setOrientation(Camera camera, Camera.Parameters parameters) {
       if (view.getWidth() < view.getHeight()){
-          if (Build.VERSION.SDK_INT==7) {
+          if (Build.VERSION.SDK_INT<=7) {
               parameters.set("orientation", "portrait");
               parameters.setRotation(90);
           } else {


### PR DESCRIPTION
Gradle 0.11 requires build tools 19.1.0 and will not build using 19.0.0.
Also, there is a new revision of the support-v4 library which the library should use.
